### PR TITLE
gui: Re-apply missing symbols needed for WFD libs

### DIFF
--- a/libs/gui/SurfaceComposerClient.cpp
+++ b/libs/gui/SurfaceComposerClient.cpp
@@ -1298,6 +1298,15 @@ status_t SurfaceComposerClient::destroyVirtualDisplay(const sp<IBinder>& display
             .transactionError();
 }
 
+sp<IBinder> SurfaceComposerClient::createDisplay(const String8& displayName, bool isSecure,
+                                                 float requestedRefereshRate) {
+    return SurfaceComposerClient::createVirtualDisplay(std::string(displayName.c_str()), isSecure, kEmpty, requestedRefereshRate);
+}
+
+void SurfaceComposerClient::destroyDisplay(const sp<IBinder>& displayToken) {
+    SurfaceComposerClient::destroyVirtualDisplay(displayToken);
+}
+
 std::vector<PhysicalDisplayId> SurfaceComposerClient::getPhysicalDisplayIds() {
     std::vector<int64_t> displayIds;
     std::vector<PhysicalDisplayId> physicalDisplayIds;

--- a/libs/gui/include/gui/SurfaceComposerClient.h
+++ b/libs/gui/include/gui/SurfaceComposerClient.h
@@ -382,6 +382,11 @@ public:
 
     static status_t destroyVirtualDisplay(const sp<IBinder>& displayToken);
 
+    static sp<IBinder> createDisplay(const String8& displayName, bool isSecure,
+                                            float requestedRefreshRate = 0);
+
+    static void destroyDisplay(const sp<IBinder>& displayToken);
+
     static std::vector<PhysicalDisplayId> getPhysicalDisplayIds();
 
     static sp<IBinder> getPhysicalDisplayToken(PhysicalDisplayId displayId);


### PR DESCRIPTION
 The change made at commit d53801c5273e34bc767e606454d32aa50f38ece8
 updated the function names and arguments.

Change-Id: I491e4e5b8fe20fcec0eab3246c7ef4ff3ecc43b9